### PR TITLE
fix: make form-js a production dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,10 @@
       "name": "@bpmn-io/form-variable-provider",
       "version": "1.3.0",
       "license": "MIT",
+      "dependencies": {
+        "@bpmn-io/form-js": ">=1.1.0"
+      },
       "devDependencies": {
-        "@bpmn-io/form-js": "^1.6.0",
         "@bpmn-io/variable-resolver": "^1.2.0",
         "@rollup/plugin-commonjs": "^25.0.7",
         "@rollup/plugin-json": "^6.1.0",
@@ -44,7 +46,6 @@
         "zeebe-bpmn-moddle": "^1.0.0"
       },
       "peerDependencies": {
-        "@bpmn-io/form-js": ">=1.1.0",
         "@bpmn-io/variable-resolver": "*",
         "bpmn-js": "*"
       }
@@ -535,7 +536,6 @@
       "version": "0.1.0-alpha.2",
       "resolved": "https://registry.npmjs.org/@bpmn-io/cm-theme/-/cm-theme-0.1.0-alpha.2.tgz",
       "integrity": "sha512-ZILgiYzxk3KMvxplUXmdRFQo45/JehDPg5k9tWfehmzUOSE13ssyLPil8uCloMQnb3yyzyOWTjb/wzKXTHlFQw==",
-      "dev": true,
       "dependencies": {
         "@codemirror/language": "^6.3.1",
         "@codemirror/view": "^6.5.1",
@@ -556,7 +556,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@bpmn-io/draggle/-/draggle-4.0.0.tgz",
       "integrity": "sha512-tr2ANCOgR9hR6Gc3x1r6JiWSwiFflFHdF0ilN8Pl5P1Q9kzsWuoTnzwVLHLQt0Ly6CiiwHJ9x+LTkJ5Bd3b3qA==",
-      "dev": true,
       "dependencies": {
         "contra": "^1.9.4",
         "crossvent": "^1.5.5"
@@ -575,7 +574,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@bpmn-io/feel-editor/-/feel-editor-1.0.1.tgz",
       "integrity": "sha512-k6OsR1Ja4FzJD31ZE1NcrjWq01poEQX5SvORVqYiUm3J0pdhFfY6Qyhoe54nk9ONihmKpGEHRtQFOdB8aaUxOw==",
-      "dev": true,
       "dependencies": {
         "@bpmn-io/feel-lint": "^1.0.0",
         "@codemirror/autocomplete": "^6.3.2",
@@ -596,7 +594,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@bpmn-io/feel-lint/-/feel-lint-1.1.0.tgz",
       "integrity": "sha512-/StDR3LsWWo2lAEup9fLkH1fqXN3wSkvYBo4KzkQW3zp1QKhqI906bIz1ncmJXi6ao5wWH6YEdjvS1G906D9lQ==",
-      "dev": true,
       "dependencies": {
         "@codemirror/language": "^6.8.0",
         "lezer-feel": "^1.2.0"
@@ -606,31 +603,28 @@
       }
     },
     "node_modules/@bpmn-io/form-js": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/form-js/-/form-js-1.6.0.tgz",
-      "integrity": "sha512-NPyKmgv4SXpdSCG/rWvBkLzE2QCoLano+4rWt1JGY297Z2vc/zv4k0A88l10RtP4tsNSVRKZHLkUZ6rHnMqJcg==",
-      "dev": true,
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/form-js/-/form-js-1.6.4.tgz",
+      "integrity": "sha512-hGiUOfb0+VXG09Ff6bihVMWHrLX0JVQ+/k7BXW31uV+vOL4DoFpzhXnlrfJIH/LY3MJLPoqHjaHK1MU/cM9KWg==",
       "dependencies": {
-        "@bpmn-io/form-js-carbon-styles": "^1.6.0",
-        "@bpmn-io/form-js-editor": "^1.6.0",
-        "@bpmn-io/form-js-playground": "^1.6.0",
-        "@bpmn-io/form-js-viewer": "^1.6.0"
+        "@bpmn-io/form-js-carbon-styles": "^1.6.4",
+        "@bpmn-io/form-js-editor": "^1.6.4",
+        "@bpmn-io/form-js-playground": "^1.6.4",
+        "@bpmn-io/form-js-viewer": "^1.6.4"
       }
     },
     "node_modules/@bpmn-io/form-js-carbon-styles": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/form-js-carbon-styles/-/form-js-carbon-styles-1.6.0.tgz",
-      "integrity": "sha512-gWJB5v09sRx1kbx9hyfTFx9khq2JwdrV1C94pboG61vsfQsGZfAuu+PtJFvWM+uyM+itVYfgLDLefoyi1HMyvg==",
-      "dev": true
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/form-js-carbon-styles/-/form-js-carbon-styles-1.6.4.tgz",
+      "integrity": "sha512-X0a+q9vTgWd8iJv5HIcAiVsNsTm9dcFXlPMBvajPMF80xJepPCzZEUjuCZe9VIJE7k54ITO7WmuZk6ZELRDvKA=="
     },
     "node_modules/@bpmn-io/form-js-editor": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/form-js-editor/-/form-js-editor-1.6.0.tgz",
-      "integrity": "sha512-9Q7W9Nz7+/XRjIUrbXE/Ky41frk0+kqmUuxSk8dT2zpUu0xXtieBQiTBfBbgJsRl87dxSnUJZ0+E5P3qEKOI3g==",
-      "dev": true,
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/form-js-editor/-/form-js-editor-1.6.4.tgz",
+      "integrity": "sha512-8sSirJOJ336QiZCW2ZYQD6Z5cVII733osdx06Xa2L2e7A/G9j3uU+pCPOd2KI+4M4ecfzOffsHB5g4H5l4zPow==",
       "dependencies": {
         "@bpmn-io/draggle": "^4.0.0",
-        "@bpmn-io/form-js-viewer": "^1.6.0",
+        "@bpmn-io/form-js-viewer": "^1.6.4",
         "@bpmn-io/properties-panel": "^3.13.0",
         "array-move": "^3.0.1",
         "big.js": "^6.2.1",
@@ -644,7 +638,6 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-6.2.1.tgz",
       "integrity": "sha512-bCtHMwL9LeDIozFn+oNhhFoq+yQ3BNdnsLSASUxLciOb1vgvpHsIO1dsENiGMgbb4SkP5TrzWzRiLddn8ahVOQ==",
-      "dev": true,
       "engines": {
         "node": "*"
       },
@@ -654,13 +647,12 @@
       }
     },
     "node_modules/@bpmn-io/form-js-playground": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/form-js-playground/-/form-js-playground-1.6.0.tgz",
-      "integrity": "sha512-h9W5hzKdgpK9vdhZeJJVWDbnTa3R1ywd1MA4YE88DjY+jrL29YRFia6yxsoj/wH7YLMAUrUxHwGCXvcjikTYvw==",
-      "dev": true,
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/form-js-playground/-/form-js-playground-1.6.4.tgz",
+      "integrity": "sha512-YTne51geiVLjEWip9xN6wvW2mca6XpywVmUECDGC51IKHy+D+kNANUtNx9XSdjiMGGljDmlQaPiZfSMwFXoN1A==",
       "dependencies": {
-        "@bpmn-io/form-js-editor": "^1.6.0",
-        "@bpmn-io/form-js-viewer": "^1.6.0",
+        "@bpmn-io/form-js-editor": "^1.6.4",
+        "@bpmn-io/form-js-viewer": "^1.6.4",
         "@codemirror/autocomplete": "^6.3.4",
         "@codemirror/commands": "^6.1.2",
         "@codemirror/lang-json": "^6.0.0",
@@ -679,14 +671,12 @@
     "node_modules/@bpmn-io/form-js-playground/node_modules/component-event": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/component-event/-/component-event-0.1.4.tgz",
-      "integrity": "sha512-GMwOG8MnUHP1l8DZx1ztFO0SJTFnIzZnBDkXAj8RM2ntV2A6ALlDxgbMY1Fvxlg6WPQ+5IM/a6vg4PEYbjg/Rw==",
-      "dev": true
+      "integrity": "sha512-GMwOG8MnUHP1l8DZx1ztFO0SJTFnIzZnBDkXAj8RM2ntV2A6ALlDxgbMY1Fvxlg6WPQ+5IM/a6vg4PEYbjg/Rw=="
     },
     "node_modules/@bpmn-io/form-js-playground/node_modules/file-drops": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/file-drops/-/file-drops-0.4.0.tgz",
       "integrity": "sha512-dPLRxrQ/sWHyU1DMf72doyyFuqeR/T8hJ97coJHXmdeHvqMTdOMJ/PLsHKjQzDHC8TBQO0rDUinDEXz3WGTnQA==",
-      "dev": true,
       "dependencies": {
         "min-dom": "^3.1.1"
       }
@@ -694,14 +684,12 @@
     "node_modules/@bpmn-io/form-js-playground/node_modules/min-dash": {
       "version": "3.8.1",
       "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-3.8.1.tgz",
-      "integrity": "sha512-evumdlmIlg9mbRVPbC4F5FuRhNmcMS5pvuBUbqb1G9v09Ro0ImPEgz5n3khir83lFok1inKqVDjnKEg3GpDxQg==",
-      "dev": true
+      "integrity": "sha512-evumdlmIlg9mbRVPbC4F5FuRhNmcMS5pvuBUbqb1G9v09Ro0ImPEgz5n3khir83lFok1inKqVDjnKEg3GpDxQg=="
     },
     "node_modules/@bpmn-io/form-js-playground/node_modules/min-dom": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-3.2.1.tgz",
       "integrity": "sha512-v6YCmnDzxk4rRJntWTUiwggLupPw/8ZSRqUq0PDaBwVZEO/wYzCH4SKVBV+KkEvf3u0XaWHly5JEosPtqRATZA==",
-      "dev": true,
       "dependencies": {
         "component-event": "^0.1.4",
         "domify": "^1.3.1",
@@ -711,10 +699,9 @@
       }
     },
     "node_modules/@bpmn-io/form-js-viewer": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/form-js-viewer/-/form-js-viewer-1.6.0.tgz",
-      "integrity": "sha512-YrnIOlvHAaTd+elyxFCu4mYErMLx+yLZcrGmHUhdfcHepSSZfI8LLDQ4gv3ipPqlAZcuBsK+IKn3fulQWXPL8Q==",
-      "dev": true,
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/form-js-viewer/-/form-js-viewer-1.6.4.tgz",
+      "integrity": "sha512-YOllEnc1dKkIrva59Jj31d3HkLjTnWDMY+tOL4XliFrm5a4fMuwUshxXH4J7buW2nRZJzD62tTQk2CAsj69Epg==",
       "dependencies": {
         "@carbon/grid": "^11.11.0",
         "big.js": "^6.2.1",
@@ -724,6 +711,7 @@
         "feelin": "^3.0.0",
         "flatpickr": "^4.6.13",
         "ids": "^1.0.0",
+        "lodash": "^4.5.0",
         "min-dash": "^4.0.0",
         "preact": "^10.5.14",
         "preact-markup": "^2.1.1",
@@ -734,7 +722,6 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-6.2.1.tgz",
       "integrity": "sha512-bCtHMwL9LeDIozFn+oNhhFoq+yQ3BNdnsLSASUxLciOb1vgvpHsIO1dsENiGMgbb4SkP5TrzWzRiLddn8ahVOQ==",
-      "dev": true,
       "engines": {
         "node": "*"
       },
@@ -747,7 +734,6 @@
       "version": "3.13.0",
       "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-3.13.0.tgz",
       "integrity": "sha512-KaeHwZpWDycSj8mDnDT/iO5TvyL9eYw+oHbj/69BDMblDp4xenUasWKrif5chZdt/B9gGnVtJp4vIdvlauC/XA==",
-      "dev": true,
       "dependencies": {
         "@bpmn-io/feel-editor": "^1.0.0",
         "@codemirror/view": "^6.14.0",
@@ -780,7 +766,6 @@
       "version": "11.21.0",
       "resolved": "https://registry.npmjs.org/@carbon/grid/-/grid-11.21.0.tgz",
       "integrity": "sha512-Zzhos2we+HqM0obdQgma+OvLoM9dNGq07YcLxFxrc/vEOn/D01sner6dyMMqS2y8036zIaoqVMGArSzPfoxrLA==",
-      "dev": true,
       "dependencies": {
         "@carbon/layout": "^11.20.0"
       }
@@ -788,14 +773,12 @@
     "node_modules/@carbon/layout": {
       "version": "11.20.0",
       "resolved": "https://registry.npmjs.org/@carbon/layout/-/layout-11.20.0.tgz",
-      "integrity": "sha512-G9eJE3xb/J98Id9VvTA/b4v+2i/c+IiHAhxNPc0PPpPN6C/r6U4gJsG4yPgQnbuIU42cP9L8OvCrQr0mbrCMlA==",
-      "dev": true
+      "integrity": "sha512-G9eJE3xb/J98Id9VvTA/b4v+2i/c+IiHAhxNPc0PPpPN6C/r6U4gJsG4yPgQnbuIU42cP9L8OvCrQr0mbrCMlA=="
     },
     "node_modules/@codemirror/autocomplete": {
       "version": "6.11.0",
       "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.11.0.tgz",
       "integrity": "sha512-LCPH3W+hl5vcO7OzEQgX6NpKuKVyiKFLGAy7FXROF6nUpsWUdQEgUb3fe/g7B0E1KZCRFfgzdKASt6Wly2UOBg==",
-      "dev": true,
       "dependencies": {
         "@codemirror/language": "^6.0.0",
         "@codemirror/state": "^6.0.0",
@@ -813,7 +796,6 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.3.0.tgz",
       "integrity": "sha512-tFfcxRIlOWiQDFhjBSWJ10MxcvbCIsRr6V64SgrcaY0MwNk32cUOcCuNlWo8VjV4qRQCgNgUAnIeo0svkk4R5Q==",
-      "dev": true,
       "dependencies": {
         "@codemirror/language": "^6.0.0",
         "@codemirror/state": "^6.2.0",
@@ -825,7 +807,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/@codemirror/lang-json/-/lang-json-6.0.1.tgz",
       "integrity": "sha512-+T1flHdgpqDDlJZ2Lkil/rLiRy684WMLc74xUnjJH48GQdfJo/pudlTRreZmKwzP8/tGdKf83wlbAdOCzlJOGQ==",
-      "dev": true,
       "dependencies": {
         "@codemirror/language": "^6.0.0",
         "@lezer/json": "^1.0.0"
@@ -835,7 +816,6 @@
       "version": "6.9.2",
       "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.9.2.tgz",
       "integrity": "sha512-QGTQXSpAKDIzaSE96zNK1UfIUhPgkT1CLjh1N5qVzZuxgsEOhz5RqaN8QCIdyOQklGLx3MgHd9YrE3X3+Pl1ow==",
-      "dev": true,
       "dependencies": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.0.0",
@@ -849,7 +829,6 @@
       "version": "6.4.2",
       "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.4.2.tgz",
       "integrity": "sha512-wzRkluWb1ptPKdzlsrbwwjYCPLgzU6N88YBAmlZi8WFyuiEduSd05MnJYNogzyc8rPK7pj6m95ptUApc8sHKVA==",
-      "dev": true,
       "dependencies": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.0.0",
@@ -860,7 +839,6 @@
       "version": "6.5.5",
       "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.5.5.tgz",
       "integrity": "sha512-PIEN3Ke1buPod2EHbJsoQwlbpkz30qGZKcnmH1eihq9+bPQx8gelauUwLYaY4vBOuBAuEhmpDLii4rj/uO0yMA==",
-      "dev": true,
       "dependencies": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.0.0",
@@ -870,14 +848,12 @@
     "node_modules/@codemirror/state": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.3.1.tgz",
-      "integrity": "sha512-88e4HhMtKJyw6fKprGaN/yZfiaoGYOi2nM45YCUC6R/kex9sxFWBDGatS1vk4lMgnWmdIIB9tk8Gj1LmL8YfvA==",
-      "dev": true
+      "integrity": "sha512-88e4HhMtKJyw6fKprGaN/yZfiaoGYOi2nM45YCUC6R/kex9sxFWBDGatS1vk4lMgnWmdIIB9tk8Gj1LmL8YfvA=="
     },
     "node_modules/@codemirror/view": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.22.0.tgz",
       "integrity": "sha512-6zLj4YIoIpfTGKrDMTbeZRpa8ih4EymMCKmddEDcJWrCdp/N1D46B38YEz4creTb4T177AVS9EyXkLeC/HL2jA==",
-      "dev": true,
       "dependencies": {
         "@codemirror/state": "^6.1.4",
         "style-mod": "^4.1.0",
@@ -1158,26 +1134,24 @@
       }
     },
     "node_modules/@lezer/common": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.1.1.tgz",
-      "integrity": "sha512-aAPB9YbvZHqAW+bIwiuuTDGB4DG0sYNRObGLxud8cW7osw1ZQxfDuTZ8KQiqfZ0QJGcR34CvpTMDXEyo/+Htgg==",
-      "dev": true
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.2.0.tgz",
+      "integrity": "sha512-Wmvlm4q6tRpwiy20TnB3yyLTZim38Tkc50dPY8biQRwqE+ati/wD84rm3N15hikvdT4uSg9phs9ubjvcLmkpKg=="
     },
     "node_modules/@lezer/highlight": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.1.6.tgz",
       "integrity": "sha512-cmSJYa2us+r3SePpRCjN5ymCqCPv+zyXmDl0ciWtVaNiORT/MxM7ZgOMQZADD0o51qOaOg24qc/zBViOIwAjJg==",
-      "dev": true,
       "dependencies": {
         "@lezer/common": "^1.0.0"
       }
     },
     "node_modules/@lezer/json": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@lezer/json/-/json-1.0.1.tgz",
-      "integrity": "sha512-nkVC27qiEZEjySbi6gQRuMwa2sDu2PtfjSgz0A4QF81QyRGm3kb2YRzLcOPcTEtmcwvrX/cej7mlhbwViA4WJw==",
-      "dev": true,
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@lezer/json/-/json-1.0.2.tgz",
+      "integrity": "sha512-xHT2P4S5eeCYECyKNPhr4cbEL9tc8w83SPwRC373o9uEdrvGKTZoJVAGxpOsZckMlEh9W23Pc72ew918RWQOBQ==",
       "dependencies": {
+        "@lezer/common": "^1.2.0",
         "@lezer/highlight": "^1.0.0",
         "@lezer/lr": "^1.0.0"
       }
@@ -1186,7 +1160,6 @@
       "version": "1.3.14",
       "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.3.14.tgz",
       "integrity": "sha512-z5mY4LStlA3yL7aHT/rqgG614cfcvklS+8oFRFBYrs4YaWLJyKKM4+nN6KopToX0o9Hj6zmH6M5kinOYuy06ug==",
-      "dev": true,
       "dependencies": {
         "@lezer/common": "^1.0.0"
       }
@@ -1195,7 +1168,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@lezer/markdown/-/markdown-1.1.1.tgz",
       "integrity": "sha512-kmxvLnXCogUx2mexslWwVME1W2GQP76pwUODcFXLsuubuK41TcEJhKRm2FTKugNfEkUIspJNq9+jNo6b7dxVLA==",
-      "dev": true,
       "dependencies": {
         "@lezer/common": "^1.0.0",
         "@lezer/highlight": "^1.0.0"
@@ -2067,7 +2039,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/array-move/-/array-move-3.0.1.tgz",
       "integrity": "sha512-H3Of6NIn2nNU1gsVDqDnYKY/LCdWvCMMOWifNGhKcVQgiZ6nOek39aESOvro6zmueP07exSl93YLvkN4fZOkSg==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -2178,8 +2149,7 @@
     "node_modules/atoa": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/atoa/-/atoa-1.0.0.tgz",
-      "integrity": "sha512-VVE1H6cc4ai+ZXo/CRWoJiHXrA1qfA31DPnx6D20+kSI547hQN5Greh51LQ1baMRMfxO5K5M4ImMtZbZt2DODQ==",
-      "dev": true
+      "integrity": "sha512-VVE1H6cc4ai+ZXo/CRWoJiHXrA1qfA31DPnx6D20+kSI547hQN5Greh51LQ1baMRMfxO5K5M4ImMtZbZt2DODQ=="
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.5",
@@ -2731,8 +2701,7 @@
     "node_modules/classnames": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
-      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==",
-      "dev": true
+      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
     },
     "node_modules/cliui": {
       "version": "7.0.4",
@@ -2758,7 +2727,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.1.tgz",
       "integrity": "sha512-J8j+nZ+CdWmIeFIGXEFbFPtpiYacFMDR8GlHK3IyHQJMCaVRfGx9NT+Hxivv1ckLWPvNdZqndbr/7lVhrf/Svg==",
-      "dev": true,
       "dependencies": {
         "@codemirror/autocomplete": "^6.0.0",
         "@codemirror/commands": "^6.0.0",
@@ -2808,8 +2776,7 @@
     "node_modules/component-event": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/component-event/-/component-event-0.2.1.tgz",
-      "integrity": "sha512-wGA++isMqiDq1jPYeyv2as/Bt/u+3iLW0rEa+8NQ82jAv3TgqMiCM+B2SaBdn2DfLilLjjq736YcezihRYhfxw==",
-      "dev": true
+      "integrity": "sha512-wGA++isMqiDq1jPYeyv2as/Bt/u+3iLW0rEa+8NQ82jAv3TgqMiCM+B2SaBdn2DfLilLjjq736YcezihRYhfxw=="
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -2860,7 +2827,6 @@
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/contra/-/contra-1.9.4.tgz",
       "integrity": "sha512-N9ArHAqwR/lhPq4OdIAwH4e1btn6EIZMAz4TazjnzCiVECcWUPTma+dRAM38ERImEJBh8NiCCpjoQruSZ+agYg==",
-      "dev": true,
       "dependencies": {
         "atoa": "1.0.0",
         "ticky": "1.0.1"
@@ -2923,8 +2889,7 @@
     "node_modules/crelt": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
-      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
-      "dev": true
+      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g=="
     },
     "node_modules/cross-env": {
       "version": "7.0.3",
@@ -2971,7 +2936,6 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/crossvent/-/crossvent-1.5.5.tgz",
       "integrity": "sha512-MY4xhBYEnVi+pmTpHCOCsCLYczc0PVtGdPBz6NXNXxikLaUZo4HdAeUb1UqAo3t3yXAloSelTmfxJ+/oUqkW5w==",
-      "dev": true,
       "dependencies": {
         "custom-event": "^1.0.0"
       }
@@ -2979,8 +2943,7 @@
     "node_modules/custom-event": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/custom-event/-/custom-event-1.0.1.tgz",
-      "integrity": "sha512-GAj5FOq0Hd+RsCGVJxZuKaIDXDf3h6GQoNEjFgbLLI/trgtavwUbSnZ5pVfg27DVCaWjIohryS0JFwIJyT2cMg==",
-      "dev": true
+      "integrity": "sha512-GAj5FOq0Hd+RsCGVJxZuKaIDXDf3h6GQoNEjFgbLLI/trgtavwUbSnZ5pVfg27DVCaWjIohryS0JFwIJyT2cMg=="
     },
     "node_modules/data-uri-to-buffer": {
       "version": "6.0.1",
@@ -3188,7 +3151,6 @@
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/didi/-/didi-10.0.1.tgz",
       "integrity": "sha512-rddmyUjpIh8pIu9OVtqQjGkZB4jNOaaRMz9AClSH3WUEOoJctxpFmqjTButmI5na5sSIDpfjABe34wEvEhrjcg==",
-      "dev": true,
       "engines": {
         "node": ">= 16"
       }
@@ -3235,14 +3197,12 @@
     "node_modules/domify": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/domify/-/domify-1.4.1.tgz",
-      "integrity": "sha512-x18nuiDHMCZGXr4KJSRMf/TWYtiaRo6RX8KN9fEbW54mvbQ6pieUuerC2ahBg+kEp1wycFj8MPUI0WkIOw5E9w==",
-      "dev": true
+      "integrity": "sha512-x18nuiDHMCZGXr4KJSRMf/TWYtiaRo6RX8KN9fEbW54mvbQ6pieUuerC2ahBg+kEp1wycFj8MPUI0WkIOw5E9w=="
     },
     "node_modules/downloadjs": {
       "version": "1.4.7",
       "resolved": "https://registry.npmjs.org/downloadjs/-/downloadjs-1.4.7.tgz",
-      "integrity": "sha512-LN1gO7+u9xjU5oEScGFKvXhYf7Y/empUIIEAGBs1LzUq/rg5duiDrkuH5A2lQGd5jfMOb9X9usDa2oVXwJ0U/Q==",
-      "dev": true
+      "integrity": "sha512-LN1gO7+u9xjU5oEScGFKvXhYf7Y/empUIIEAGBs1LzUq/rg5duiDrkuH5A2lQGd5jfMOb9X9usDa2oVXwJ0U/Q=="
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -3902,7 +3862,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/feelers/-/feelers-1.2.0.tgz",
       "integrity": "sha512-EPw88XH1UUt4A5JmBrJN3dmCMAxSi54juFuNoGwPKIDz70x9VYJhrECYsDfcx+CbIVNPuoEkt9hlx07bfA1+4A==",
-      "dev": true,
       "dependencies": {
         "@bpmn-io/cm-theme": "^0.1.0-alpha.2",
         "@bpmn-io/feel-lint": "^1.1.0",
@@ -3928,7 +3887,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/feelin/-/feelin-2.3.0.tgz",
       "integrity": "sha512-QDXCQRIV6AeLYUZoSlCAM+LEIv5k0+G4UJ+hRvTG42nCsW9YWPeVFNDInJDMGC+NimA6wW+1PKKDY6X8FcKJqg==",
-      "dev": true,
       "dependencies": {
         "@lezer/lr": "^1.3.9",
         "lezer-feel": "^1.2.0",
@@ -3942,7 +3900,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/feelin/-/feelin-3.0.0.tgz",
       "integrity": "sha512-6Sgn9GTr376o1R0Pnk+RB7PjMeVXCkt8JT+3eLYMjpkrBrrFcp6r9ip4/UMMr9701Dm+5gEFGfIPeA01eY427Q==",
-      "dev": true,
       "dependencies": {
         "@lezer/lr": "^1.3.9",
         "lezer-feel": "^1.2.0",
@@ -4087,8 +4044,7 @@
     "node_modules/flatpickr": {
       "version": "4.6.13",
       "resolved": "https://registry.npmjs.org/flatpickr/-/flatpickr-4.6.13.tgz",
-      "integrity": "sha512-97PMG/aywoYpB4IvbvUJi0RQi8vearvU0oov1WW3k0WZPBMrTQVqekSX5CjSG/M4Q3i6A/0FKXC7RyAoAUUSPw==",
-      "dev": true
+      "integrity": "sha512-97PMG/aywoYpB4IvbvUJi0RQi8vearvU0oov1WW3k0WZPBMrTQVqekSX5CjSG/M4Q3i6A/0FKXC7RyAoAUUSPw=="
     },
     "node_modules/flatted": {
       "version": "3.2.7",
@@ -4100,7 +4056,6 @@
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.5.4.tgz",
       "integrity": "sha512-N7kHdlgsO/v+iD/dMoJKtsSqs5Dz/dXZVebRgJw23LDk+jMi/974zyiOYDziY2JPp8xivq9BmUGwIJMiuSBi7w==",
-      "dev": true,
       "dependencies": {
         "tabbable": "^6.2.0"
       }
@@ -4608,8 +4563,7 @@
     "node_modules/ids": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/ids/-/ids-1.0.5.tgz",
-      "integrity": "sha512-XQ0yom/4KWTL29sLG+tyuycy7UmeaM/79GRtSJq6IG9cJGIPeBz5kwDCguie3TwxaMNIc3WtPi0cTa1XYHicpw==",
-      "dev": true
+      "integrity": "sha512-XQ0yom/4KWTL29sLG+tyuycy7UmeaM/79GRtSJq6IG9cJGIPeBz5kwDCguie3TwxaMNIc3WtPi0cTa1XYHicpw=="
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
@@ -4668,8 +4622,7 @@
     "node_modules/indexof": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
-      "integrity": "sha512-i0G7hLJ1z0DE8dsqJa2rycj9dBmNKgXBvotXtZYXakU9oivfB9Uj2ZBC27qqef2U58/ZLwalxa1X/RDCdkHtVg==",
-      "dev": true
+      "integrity": "sha512-i0G7hLJ1z0DE8dsqJa2rycj9dBmNKgXBvotXtZYXakU9oivfB9Uj2ZBC27qqef2U58/ZLwalxa1X/RDCdkHtVg=="
     },
     "node_modules/inflight": {
       "version": "1.0.6",
@@ -5530,7 +5483,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/lang-feel/-/lang-feel-1.1.0.tgz",
       "integrity": "sha512-UxQoWm8G8ne9D+xrVJ4wgVM2nIiggpdCQxX8SAw+ISNFUsehm7xtwohELgXGN8dCZ6C69fsMreAjI+jPURFKdQ==",
-      "dev": true,
       "dependencies": {
         "@codemirror/autocomplete": "^6.9.1",
         "@codemirror/language": "^6.9.1",
@@ -5560,7 +5512,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/lezer-feel/-/lezer-feel-1.2.0.tgz",
       "integrity": "sha512-OgSjIEAK0YCxhwkuB1qvhqv65XmZiqLGQv8mvMOVUAcdKE6W72VV/sQ9GTgCBkAnmyB1x16WuzNRpEwpJswkkQ==",
-      "dev": true,
       "dependencies": {
         "@lezer/highlight": "^1.1.6",
         "@lezer/lr": "^1.3.12"
@@ -5644,8 +5595,7 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.get": {
       "version": "4.4.2",
@@ -5726,7 +5676,6 @@
       "version": "3.4.4",
       "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.4.4.tgz",
       "integrity": "sha512-zobTr7akeGHnv7eBOXcRgMeCP6+uyYsczwmeRCauvpvaAltgNyTbLH/+VaEAPUeWBT+1GuNmz4wC/6jtQzbbVA==",
-      "dev": true,
       "engines": {
         "node": ">=12"
       }
@@ -5803,8 +5752,7 @@
     "node_modules/matches-selector": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/matches-selector/-/matches-selector-1.2.0.tgz",
-      "integrity": "sha512-c4vLwYWyl+Ji+U43eU/G5FwxWd4ZH0ePUsFs5y0uwD9HUEFBXUQ1zUUan+78IpRD+y4pUfG0nAzNM292K7ItvA==",
-      "dev": true
+      "integrity": "sha512-c4vLwYWyl+Ji+U43eU/G5FwxWd4ZH0ePUsFs5y0uwD9HUEFBXUQ1zUUan+78IpRD+y4pUfG0nAzNM292K7ItvA=="
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
@@ -5866,14 +5814,12 @@
     "node_modules/min-dash": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-4.1.1.tgz",
-      "integrity": "sha512-r+Z6vxXLSGr+otyCPx9NKPCSixw7LdfZREPTmqfd2a/d5D6w4NCdOxRJs+HyFO6v2pQkyHroGSiINWECK+OWPg==",
-      "dev": true
+      "integrity": "sha512-r+Z6vxXLSGr+otyCPx9NKPCSixw7LdfZREPTmqfd2a/d5D6w4NCdOxRJs+HyFO6v2pQkyHroGSiINWECK+OWPg=="
     },
     "node_modules/min-dom": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-4.1.0.tgz",
       "integrity": "sha512-1lj1EyoSwY/UmTeT/hhPiZTsq+vK9D+8FAJ/53iK5jT1otkG9rJTixSKdjmTieEvdfES+sKbbTptzaQJhnacjA==",
-      "dev": true,
       "dependencies": {
         "component-event": "^0.2.1",
         "domify": "^1.4.1",
@@ -5904,8 +5850,7 @@
     "node_modules/mitt": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
-      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
-      "dev": true
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw=="
     },
     "node_modules/mkdirp": {
       "version": "0.5.6",
@@ -6914,7 +6859,6 @@
       "version": "10.17.0",
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.17.0.tgz",
       "integrity": "sha512-SNsI8cbaCcUS5tbv9nlXuCfIXnJ9ysBMWk0WnB6UWwcVA3qZ2O6FxqDFECMAMttvLQcW/HaNZUe2BLidyvrVYw==",
-      "dev": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -6924,7 +6868,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/preact-markup/-/preact-markup-2.1.1.tgz",
       "integrity": "sha512-8JL2p36mzK8XkspOyhBxUSPjYwMxDM0L5BWBZWxsZMVW8WsGQrYQDgVuDKkRspt2hwrle+Cxr/053hpc9BJwfw==",
-      "dev": true,
       "peerDependencies": {
         "preact": ">=10"
       }
@@ -7567,7 +7510,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/showdown/-/showdown-2.1.0.tgz",
       "integrity": "sha512-/6NVYu4U819R2pUIk79n67SYgJHWCce0a5xTP979WbNp0FL9MN1I1QK662IDU1b6JzKTvmhgI7T7JYIxBi3kMQ==",
-      "dev": true,
       "dependencies": {
         "commander": "^9.0.0"
       },
@@ -7583,7 +7525,6 @@
       "version": "9.5.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
       "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
-      "dev": true,
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -7977,8 +7918,7 @@
     "node_modules/style-mod": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.0.tgz",
-      "integrity": "sha512-Ca5ib8HrFn+f+0n4N4ScTIA9iTOQ7MaGS1ylHcoVqW9J7w2w8PzN6g9gKmTYgGEBH8e120+RCmhpje6jC5uGWA==",
-      "dev": true
+      "integrity": "sha512-Ca5ib8HrFn+f+0n4N4ScTIA9iTOQ7MaGS1ylHcoVqW9J7w2w8PzN6g9gKmTYgGEBH8e120+RCmhpje6jC5uGWA=="
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -8007,8 +7947,7 @@
     "node_modules/tabbable": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
-      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
-      "dev": true
+      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew=="
     },
     "node_modules/tapable": {
       "version": "2.2.1",
@@ -8151,8 +8090,7 @@
     "node_modules/ticky": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ticky/-/ticky-1.0.1.tgz",
-      "integrity": "sha512-RX35iq/D+lrsqhcPWIazM9ELkjOe30MSeoBHQHSsRwd1YuhJO5ui1K1/R0r7N3mFvbLBs33idw+eR6j+w6i/DA==",
-      "dev": true
+      "integrity": "sha512-RX35iq/D+lrsqhcPWIazM9ELkjOe30MSeoBHQHSsRwd1YuhJO5ui1K1/R0r7N3mFvbLBs33idw+eR6j+w6i/DA=="
     },
     "node_modules/tiny-svg": {
       "version": "3.0.1",
@@ -8472,8 +8410,7 @@
     "node_modules/w3c-keyname": {
       "version": "2.2.8",
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
-      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
-      "dev": true
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ=="
     },
     "node_modules/watchpack": {
       "version": "2.4.0",
@@ -9193,7 +9130,6 @@
       "version": "0.1.0-alpha.2",
       "resolved": "https://registry.npmjs.org/@bpmn-io/cm-theme/-/cm-theme-0.1.0-alpha.2.tgz",
       "integrity": "sha512-ZILgiYzxk3KMvxplUXmdRFQo45/JehDPg5k9tWfehmzUOSE13ssyLPil8uCloMQnb3yyzyOWTjb/wzKXTHlFQw==",
-      "dev": true,
       "requires": {
         "@codemirror/language": "^6.3.1",
         "@codemirror/view": "^6.5.1",
@@ -9214,7 +9150,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@bpmn-io/draggle/-/draggle-4.0.0.tgz",
       "integrity": "sha512-tr2ANCOgR9hR6Gc3x1r6JiWSwiFflFHdF0ilN8Pl5P1Q9kzsWuoTnzwVLHLQt0Ly6CiiwHJ9x+LTkJ5Bd3b3qA==",
-      "dev": true,
       "requires": {
         "contra": "^1.9.4",
         "crossvent": "^1.5.5"
@@ -9233,7 +9168,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@bpmn-io/feel-editor/-/feel-editor-1.0.1.tgz",
       "integrity": "sha512-k6OsR1Ja4FzJD31ZE1NcrjWq01poEQX5SvORVqYiUm3J0pdhFfY6Qyhoe54nk9ONihmKpGEHRtQFOdB8aaUxOw==",
-      "dev": true,
       "requires": {
         "@bpmn-io/feel-lint": "^1.0.0",
         "@codemirror/autocomplete": "^6.3.2",
@@ -9251,38 +9185,34 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@bpmn-io/feel-lint/-/feel-lint-1.1.0.tgz",
       "integrity": "sha512-/StDR3LsWWo2lAEup9fLkH1fqXN3wSkvYBo4KzkQW3zp1QKhqI906bIz1ncmJXi6ao5wWH6YEdjvS1G906D9lQ==",
-      "dev": true,
       "requires": {
         "@codemirror/language": "^6.8.0",
         "lezer-feel": "^1.2.0"
       }
     },
     "@bpmn-io/form-js": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/form-js/-/form-js-1.6.0.tgz",
-      "integrity": "sha512-NPyKmgv4SXpdSCG/rWvBkLzE2QCoLano+4rWt1JGY297Z2vc/zv4k0A88l10RtP4tsNSVRKZHLkUZ6rHnMqJcg==",
-      "dev": true,
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/form-js/-/form-js-1.6.4.tgz",
+      "integrity": "sha512-hGiUOfb0+VXG09Ff6bihVMWHrLX0JVQ+/k7BXW31uV+vOL4DoFpzhXnlrfJIH/LY3MJLPoqHjaHK1MU/cM9KWg==",
       "requires": {
-        "@bpmn-io/form-js-carbon-styles": "^1.6.0",
-        "@bpmn-io/form-js-editor": "^1.6.0",
-        "@bpmn-io/form-js-playground": "^1.6.0",
-        "@bpmn-io/form-js-viewer": "^1.6.0"
+        "@bpmn-io/form-js-carbon-styles": "^1.6.4",
+        "@bpmn-io/form-js-editor": "^1.6.4",
+        "@bpmn-io/form-js-playground": "^1.6.4",
+        "@bpmn-io/form-js-viewer": "^1.6.4"
       }
     },
     "@bpmn-io/form-js-carbon-styles": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/form-js-carbon-styles/-/form-js-carbon-styles-1.6.0.tgz",
-      "integrity": "sha512-gWJB5v09sRx1kbx9hyfTFx9khq2JwdrV1C94pboG61vsfQsGZfAuu+PtJFvWM+uyM+itVYfgLDLefoyi1HMyvg==",
-      "dev": true
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/form-js-carbon-styles/-/form-js-carbon-styles-1.6.4.tgz",
+      "integrity": "sha512-X0a+q9vTgWd8iJv5HIcAiVsNsTm9dcFXlPMBvajPMF80xJepPCzZEUjuCZe9VIJE7k54ITO7WmuZk6ZELRDvKA=="
     },
     "@bpmn-io/form-js-editor": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/form-js-editor/-/form-js-editor-1.6.0.tgz",
-      "integrity": "sha512-9Q7W9Nz7+/XRjIUrbXE/Ky41frk0+kqmUuxSk8dT2zpUu0xXtieBQiTBfBbgJsRl87dxSnUJZ0+E5P3qEKOI3g==",
-      "dev": true,
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/form-js-editor/-/form-js-editor-1.6.4.tgz",
+      "integrity": "sha512-8sSirJOJ336QiZCW2ZYQD6Z5cVII733osdx06Xa2L2e7A/G9j3uU+pCPOd2KI+4M4ecfzOffsHB5g4H5l4zPow==",
       "requires": {
         "@bpmn-io/draggle": "^4.0.0",
-        "@bpmn-io/form-js-viewer": "^1.6.0",
+        "@bpmn-io/form-js-viewer": "^1.6.4",
         "@bpmn-io/properties-panel": "^3.13.0",
         "array-move": "^3.0.1",
         "big.js": "^6.2.1",
@@ -9295,19 +9225,17 @@
         "big.js": {
           "version": "6.2.1",
           "resolved": "https://registry.npmjs.org/big.js/-/big.js-6.2.1.tgz",
-          "integrity": "sha512-bCtHMwL9LeDIozFn+oNhhFoq+yQ3BNdnsLSASUxLciOb1vgvpHsIO1dsENiGMgbb4SkP5TrzWzRiLddn8ahVOQ==",
-          "dev": true
+          "integrity": "sha512-bCtHMwL9LeDIozFn+oNhhFoq+yQ3BNdnsLSASUxLciOb1vgvpHsIO1dsENiGMgbb4SkP5TrzWzRiLddn8ahVOQ=="
         }
       }
     },
     "@bpmn-io/form-js-playground": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/form-js-playground/-/form-js-playground-1.6.0.tgz",
-      "integrity": "sha512-h9W5hzKdgpK9vdhZeJJVWDbnTa3R1ywd1MA4YE88DjY+jrL29YRFia6yxsoj/wH7YLMAUrUxHwGCXvcjikTYvw==",
-      "dev": true,
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/form-js-playground/-/form-js-playground-1.6.4.tgz",
+      "integrity": "sha512-YTne51geiVLjEWip9xN6wvW2mca6XpywVmUECDGC51IKHy+D+kNANUtNx9XSdjiMGGljDmlQaPiZfSMwFXoN1A==",
       "requires": {
-        "@bpmn-io/form-js-editor": "^1.6.0",
-        "@bpmn-io/form-js-viewer": "^1.6.0",
+        "@bpmn-io/form-js-editor": "^1.6.4",
+        "@bpmn-io/form-js-viewer": "^1.6.4",
         "@codemirror/autocomplete": "^6.3.4",
         "@codemirror/commands": "^6.1.2",
         "@codemirror/lang-json": "^6.0.0",
@@ -9326,14 +9254,12 @@
         "component-event": {
           "version": "0.1.4",
           "resolved": "https://registry.npmjs.org/component-event/-/component-event-0.1.4.tgz",
-          "integrity": "sha512-GMwOG8MnUHP1l8DZx1ztFO0SJTFnIzZnBDkXAj8RM2ntV2A6ALlDxgbMY1Fvxlg6WPQ+5IM/a6vg4PEYbjg/Rw==",
-          "dev": true
+          "integrity": "sha512-GMwOG8MnUHP1l8DZx1ztFO0SJTFnIzZnBDkXAj8RM2ntV2A6ALlDxgbMY1Fvxlg6WPQ+5IM/a6vg4PEYbjg/Rw=="
         },
         "file-drops": {
           "version": "0.4.0",
           "resolved": "https://registry.npmjs.org/file-drops/-/file-drops-0.4.0.tgz",
           "integrity": "sha512-dPLRxrQ/sWHyU1DMf72doyyFuqeR/T8hJ97coJHXmdeHvqMTdOMJ/PLsHKjQzDHC8TBQO0rDUinDEXz3WGTnQA==",
-          "dev": true,
           "requires": {
             "min-dom": "^3.1.1"
           }
@@ -9341,14 +9267,12 @@
         "min-dash": {
           "version": "3.8.1",
           "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-3.8.1.tgz",
-          "integrity": "sha512-evumdlmIlg9mbRVPbC4F5FuRhNmcMS5pvuBUbqb1G9v09Ro0ImPEgz5n3khir83lFok1inKqVDjnKEg3GpDxQg==",
-          "dev": true
+          "integrity": "sha512-evumdlmIlg9mbRVPbC4F5FuRhNmcMS5pvuBUbqb1G9v09Ro0ImPEgz5n3khir83lFok1inKqVDjnKEg3GpDxQg=="
         },
         "min-dom": {
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-3.2.1.tgz",
           "integrity": "sha512-v6YCmnDzxk4rRJntWTUiwggLupPw/8ZSRqUq0PDaBwVZEO/wYzCH4SKVBV+KkEvf3u0XaWHly5JEosPtqRATZA==",
-          "dev": true,
           "requires": {
             "component-event": "^0.1.4",
             "domify": "^1.3.1",
@@ -9360,10 +9284,9 @@
       }
     },
     "@bpmn-io/form-js-viewer": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/form-js-viewer/-/form-js-viewer-1.6.0.tgz",
-      "integrity": "sha512-YrnIOlvHAaTd+elyxFCu4mYErMLx+yLZcrGmHUhdfcHepSSZfI8LLDQ4gv3ipPqlAZcuBsK+IKn3fulQWXPL8Q==",
-      "dev": true,
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/form-js-viewer/-/form-js-viewer-1.6.4.tgz",
+      "integrity": "sha512-YOllEnc1dKkIrva59Jj31d3HkLjTnWDMY+tOL4XliFrm5a4fMuwUshxXH4J7buW2nRZJzD62tTQk2CAsj69Epg==",
       "requires": {
         "@carbon/grid": "^11.11.0",
         "big.js": "^6.2.1",
@@ -9373,6 +9296,7 @@
         "feelin": "^3.0.0",
         "flatpickr": "^4.6.13",
         "ids": "^1.0.0",
+        "lodash": "^4.5.0",
         "min-dash": "^4.0.0",
         "preact": "^10.5.14",
         "preact-markup": "^2.1.1",
@@ -9382,8 +9306,7 @@
         "big.js": {
           "version": "6.2.1",
           "resolved": "https://registry.npmjs.org/big.js/-/big.js-6.2.1.tgz",
-          "integrity": "sha512-bCtHMwL9LeDIozFn+oNhhFoq+yQ3BNdnsLSASUxLciOb1vgvpHsIO1dsENiGMgbb4SkP5TrzWzRiLddn8ahVOQ==",
-          "dev": true
+          "integrity": "sha512-bCtHMwL9LeDIozFn+oNhhFoq+yQ3BNdnsLSASUxLciOb1vgvpHsIO1dsENiGMgbb4SkP5TrzWzRiLddn8ahVOQ=="
         }
       }
     },
@@ -9391,7 +9314,6 @@
       "version": "3.13.0",
       "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-3.13.0.tgz",
       "integrity": "sha512-KaeHwZpWDycSj8mDnDT/iO5TvyL9eYw+oHbj/69BDMblDp4xenUasWKrif5chZdt/B9gGnVtJp4vIdvlauC/XA==",
-      "dev": true,
       "requires": {
         "@bpmn-io/feel-editor": "^1.0.0",
         "@codemirror/view": "^6.14.0",
@@ -9418,7 +9340,6 @@
       "version": "11.21.0",
       "resolved": "https://registry.npmjs.org/@carbon/grid/-/grid-11.21.0.tgz",
       "integrity": "sha512-Zzhos2we+HqM0obdQgma+OvLoM9dNGq07YcLxFxrc/vEOn/D01sner6dyMMqS2y8036zIaoqVMGArSzPfoxrLA==",
-      "dev": true,
       "requires": {
         "@carbon/layout": "^11.20.0"
       }
@@ -9426,14 +9347,12 @@
     "@carbon/layout": {
       "version": "11.20.0",
       "resolved": "https://registry.npmjs.org/@carbon/layout/-/layout-11.20.0.tgz",
-      "integrity": "sha512-G9eJE3xb/J98Id9VvTA/b4v+2i/c+IiHAhxNPc0PPpPN6C/r6U4gJsG4yPgQnbuIU42cP9L8OvCrQr0mbrCMlA==",
-      "dev": true
+      "integrity": "sha512-G9eJE3xb/J98Id9VvTA/b4v+2i/c+IiHAhxNPc0PPpPN6C/r6U4gJsG4yPgQnbuIU42cP9L8OvCrQr0mbrCMlA=="
     },
     "@codemirror/autocomplete": {
       "version": "6.11.0",
       "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.11.0.tgz",
       "integrity": "sha512-LCPH3W+hl5vcO7OzEQgX6NpKuKVyiKFLGAy7FXROF6nUpsWUdQEgUb3fe/g7B0E1KZCRFfgzdKASt6Wly2UOBg==",
-      "dev": true,
       "requires": {
         "@codemirror/language": "^6.0.0",
         "@codemirror/state": "^6.0.0",
@@ -9445,7 +9364,6 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.3.0.tgz",
       "integrity": "sha512-tFfcxRIlOWiQDFhjBSWJ10MxcvbCIsRr6V64SgrcaY0MwNk32cUOcCuNlWo8VjV4qRQCgNgUAnIeo0svkk4R5Q==",
-      "dev": true,
       "requires": {
         "@codemirror/language": "^6.0.0",
         "@codemirror/state": "^6.2.0",
@@ -9457,7 +9375,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/@codemirror/lang-json/-/lang-json-6.0.1.tgz",
       "integrity": "sha512-+T1flHdgpqDDlJZ2Lkil/rLiRy684WMLc74xUnjJH48GQdfJo/pudlTRreZmKwzP8/tGdKf83wlbAdOCzlJOGQ==",
-      "dev": true,
       "requires": {
         "@codemirror/language": "^6.0.0",
         "@lezer/json": "^1.0.0"
@@ -9467,7 +9384,6 @@
       "version": "6.9.2",
       "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.9.2.tgz",
       "integrity": "sha512-QGTQXSpAKDIzaSE96zNK1UfIUhPgkT1CLjh1N5qVzZuxgsEOhz5RqaN8QCIdyOQklGLx3MgHd9YrE3X3+Pl1ow==",
-      "dev": true,
       "requires": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.0.0",
@@ -9481,7 +9397,6 @@
       "version": "6.4.2",
       "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.4.2.tgz",
       "integrity": "sha512-wzRkluWb1ptPKdzlsrbwwjYCPLgzU6N88YBAmlZi8WFyuiEduSd05MnJYNogzyc8rPK7pj6m95ptUApc8sHKVA==",
-      "dev": true,
       "requires": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.0.0",
@@ -9492,7 +9407,6 @@
       "version": "6.5.5",
       "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.5.5.tgz",
       "integrity": "sha512-PIEN3Ke1buPod2EHbJsoQwlbpkz30qGZKcnmH1eihq9+bPQx8gelauUwLYaY4vBOuBAuEhmpDLii4rj/uO0yMA==",
-      "dev": true,
       "requires": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.0.0",
@@ -9502,14 +9416,12 @@
     "@codemirror/state": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.3.1.tgz",
-      "integrity": "sha512-88e4HhMtKJyw6fKprGaN/yZfiaoGYOi2nM45YCUC6R/kex9sxFWBDGatS1vk4lMgnWmdIIB9tk8Gj1LmL8YfvA==",
-      "dev": true
+      "integrity": "sha512-88e4HhMtKJyw6fKprGaN/yZfiaoGYOi2nM45YCUC6R/kex9sxFWBDGatS1vk4lMgnWmdIIB9tk8Gj1LmL8YfvA=="
     },
     "@codemirror/view": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.22.0.tgz",
       "integrity": "sha512-6zLj4YIoIpfTGKrDMTbeZRpa8ih4EymMCKmddEDcJWrCdp/N1D46B38YEz4creTb4T177AVS9EyXkLeC/HL2jA==",
-      "dev": true,
       "requires": {
         "@codemirror/state": "^6.1.4",
         "style-mod": "^4.1.0",
@@ -9722,26 +9634,24 @@
       }
     },
     "@lezer/common": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.1.1.tgz",
-      "integrity": "sha512-aAPB9YbvZHqAW+bIwiuuTDGB4DG0sYNRObGLxud8cW7osw1ZQxfDuTZ8KQiqfZ0QJGcR34CvpTMDXEyo/+Htgg==",
-      "dev": true
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.2.0.tgz",
+      "integrity": "sha512-Wmvlm4q6tRpwiy20TnB3yyLTZim38Tkc50dPY8biQRwqE+ati/wD84rm3N15hikvdT4uSg9phs9ubjvcLmkpKg=="
     },
     "@lezer/highlight": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.1.6.tgz",
       "integrity": "sha512-cmSJYa2us+r3SePpRCjN5ymCqCPv+zyXmDl0ciWtVaNiORT/MxM7ZgOMQZADD0o51qOaOg24qc/zBViOIwAjJg==",
-      "dev": true,
       "requires": {
         "@lezer/common": "^1.0.0"
       }
     },
     "@lezer/json": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@lezer/json/-/json-1.0.1.tgz",
-      "integrity": "sha512-nkVC27qiEZEjySbi6gQRuMwa2sDu2PtfjSgz0A4QF81QyRGm3kb2YRzLcOPcTEtmcwvrX/cej7mlhbwViA4WJw==",
-      "dev": true,
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@lezer/json/-/json-1.0.2.tgz",
+      "integrity": "sha512-xHT2P4S5eeCYECyKNPhr4cbEL9tc8w83SPwRC373o9uEdrvGKTZoJVAGxpOsZckMlEh9W23Pc72ew918RWQOBQ==",
       "requires": {
+        "@lezer/common": "^1.2.0",
         "@lezer/highlight": "^1.0.0",
         "@lezer/lr": "^1.0.0"
       }
@@ -9750,7 +9660,6 @@
       "version": "1.3.14",
       "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.3.14.tgz",
       "integrity": "sha512-z5mY4LStlA3yL7aHT/rqgG614cfcvklS+8oFRFBYrs4YaWLJyKKM4+nN6KopToX0o9Hj6zmH6M5kinOYuy06ug==",
-      "dev": true,
       "requires": {
         "@lezer/common": "^1.0.0"
       }
@@ -9759,7 +9668,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@lezer/markdown/-/markdown-1.1.1.tgz",
       "integrity": "sha512-kmxvLnXCogUx2mexslWwVME1W2GQP76pwUODcFXLsuubuK41TcEJhKRm2FTKugNfEkUIspJNq9+jNo6b7dxVLA==",
-      "dev": true,
       "requires": {
         "@lezer/common": "^1.0.0",
         "@lezer/highlight": "^1.0.0"
@@ -10434,8 +10342,7 @@
     "array-move": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/array-move/-/array-move-3.0.1.tgz",
-      "integrity": "sha512-H3Of6NIn2nNU1gsVDqDnYKY/LCdWvCMMOWifNGhKcVQgiZ6nOek39aESOvro6zmueP07exSl93YLvkN4fZOkSg==",
-      "dev": true
+      "integrity": "sha512-H3Of6NIn2nNU1gsVDqDnYKY/LCdWvCMMOWifNGhKcVQgiZ6nOek39aESOvro6zmueP07exSl93YLvkN4fZOkSg=="
     },
     "array.prototype.flat": {
       "version": "1.3.1",
@@ -10516,8 +10423,7 @@
     "atoa": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/atoa/-/atoa-1.0.0.tgz",
-      "integrity": "sha512-VVE1H6cc4ai+ZXo/CRWoJiHXrA1qfA31DPnx6D20+kSI547hQN5Greh51LQ1baMRMfxO5K5M4ImMtZbZt2DODQ==",
-      "dev": true
+      "integrity": "sha512-VVE1H6cc4ai+ZXo/CRWoJiHXrA1qfA31DPnx6D20+kSI547hQN5Greh51LQ1baMRMfxO5K5M4ImMtZbZt2DODQ=="
     },
     "available-typed-arrays": {
       "version": "1.0.5",
@@ -10897,8 +10803,7 @@
     "classnames": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
-      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==",
-      "dev": true
+      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
     },
     "cliui": {
       "version": "7.0.4",
@@ -10921,7 +10826,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.1.tgz",
       "integrity": "sha512-J8j+nZ+CdWmIeFIGXEFbFPtpiYacFMDR8GlHK3IyHQJMCaVRfGx9NT+Hxivv1ckLWPvNdZqndbr/7lVhrf/Svg==",
-      "dev": true,
       "requires": {
         "@codemirror/autocomplete": "^6.0.0",
         "@codemirror/commands": "^6.0.0",
@@ -10968,8 +10872,7 @@
     "component-event": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/component-event/-/component-event-0.2.1.tgz",
-      "integrity": "sha512-wGA++isMqiDq1jPYeyv2as/Bt/u+3iLW0rEa+8NQ82jAv3TgqMiCM+B2SaBdn2DfLilLjjq736YcezihRYhfxw==",
-      "dev": true
+      "integrity": "sha512-wGA++isMqiDq1jPYeyv2as/Bt/u+3iLW0rEa+8NQ82jAv3TgqMiCM+B2SaBdn2DfLilLjjq736YcezihRYhfxw=="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -11016,7 +10919,6 @@
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/contra/-/contra-1.9.4.tgz",
       "integrity": "sha512-N9ArHAqwR/lhPq4OdIAwH4e1btn6EIZMAz4TazjnzCiVECcWUPTma+dRAM38ERImEJBh8NiCCpjoQruSZ+agYg==",
-      "dev": true,
       "requires": {
         "atoa": "1.0.0",
         "ticky": "1.0.1"
@@ -11059,8 +10961,7 @@
     "crelt": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
-      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
-      "dev": true
+      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g=="
     },
     "cross-env": {
       "version": "7.0.3",
@@ -11095,7 +10996,6 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/crossvent/-/crossvent-1.5.5.tgz",
       "integrity": "sha512-MY4xhBYEnVi+pmTpHCOCsCLYczc0PVtGdPBz6NXNXxikLaUZo4HdAeUb1UqAo3t3yXAloSelTmfxJ+/oUqkW5w==",
-      "dev": true,
       "requires": {
         "custom-event": "^1.0.0"
       }
@@ -11103,8 +11003,7 @@
     "custom-event": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/custom-event/-/custom-event-1.0.1.tgz",
-      "integrity": "sha512-GAj5FOq0Hd+RsCGVJxZuKaIDXDf3h6GQoNEjFgbLLI/trgtavwUbSnZ5pVfg27DVCaWjIohryS0JFwIJyT2cMg==",
-      "dev": true
+      "integrity": "sha512-GAj5FOq0Hd+RsCGVJxZuKaIDXDf3h6GQoNEjFgbLLI/trgtavwUbSnZ5pVfg27DVCaWjIohryS0JFwIJyT2cMg=="
     },
     "data-uri-to-buffer": {
       "version": "6.0.1",
@@ -11257,8 +11156,7 @@
     "didi": {
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/didi/-/didi-10.0.1.tgz",
-      "integrity": "sha512-rddmyUjpIh8pIu9OVtqQjGkZB4jNOaaRMz9AClSH3WUEOoJctxpFmqjTButmI5na5sSIDpfjABe34wEvEhrjcg==",
-      "dev": true
+      "integrity": "sha512-rddmyUjpIh8pIu9OVtqQjGkZB4jNOaaRMz9AClSH3WUEOoJctxpFmqjTButmI5na5sSIDpfjABe34wEvEhrjcg=="
     },
     "diff": {
       "version": "5.0.0",
@@ -11296,14 +11194,12 @@
     "domify": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/domify/-/domify-1.4.1.tgz",
-      "integrity": "sha512-x18nuiDHMCZGXr4KJSRMf/TWYtiaRo6RX8KN9fEbW54mvbQ6pieUuerC2ahBg+kEp1wycFj8MPUI0WkIOw5E9w==",
-      "dev": true
+      "integrity": "sha512-x18nuiDHMCZGXr4KJSRMf/TWYtiaRo6RX8KN9fEbW54mvbQ6pieUuerC2ahBg+kEp1wycFj8MPUI0WkIOw5E9w=="
     },
     "downloadjs": {
       "version": "1.4.7",
       "resolved": "https://registry.npmjs.org/downloadjs/-/downloadjs-1.4.7.tgz",
-      "integrity": "sha512-LN1gO7+u9xjU5oEScGFKvXhYf7Y/empUIIEAGBs1LzUq/rg5duiDrkuH5A2lQGd5jfMOb9X9usDa2oVXwJ0U/Q==",
-      "dev": true
+      "integrity": "sha512-LN1gO7+u9xjU5oEScGFKvXhYf7Y/empUIIEAGBs1LzUq/rg5duiDrkuH5A2lQGd5jfMOb9X9usDa2oVXwJ0U/Q=="
     },
     "ee-first": {
       "version": "1.1.1",
@@ -11817,7 +11713,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/feelers/-/feelers-1.2.0.tgz",
       "integrity": "sha512-EPw88XH1UUt4A5JmBrJN3dmCMAxSi54juFuNoGwPKIDz70x9VYJhrECYsDfcx+CbIVNPuoEkt9hlx07bfA1+4A==",
-      "dev": true,
       "requires": {
         "@bpmn-io/cm-theme": "^0.1.0-alpha.2",
         "@bpmn-io/feel-lint": "^1.1.0",
@@ -11840,7 +11735,6 @@
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/feelin/-/feelin-2.3.0.tgz",
           "integrity": "sha512-QDXCQRIV6AeLYUZoSlCAM+LEIv5k0+G4UJ+hRvTG42nCsW9YWPeVFNDInJDMGC+NimA6wW+1PKKDY6X8FcKJqg==",
-          "dev": true,
           "requires": {
             "@lezer/lr": "^1.3.9",
             "lezer-feel": "^1.2.0",
@@ -11853,7 +11747,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/feelin/-/feelin-3.0.0.tgz",
       "integrity": "sha512-6Sgn9GTr376o1R0Pnk+RB7PjMeVXCkt8JT+3eLYMjpkrBrrFcp6r9ip4/UMMr9701Dm+5gEFGfIPeA01eY427Q==",
-      "dev": true,
       "requires": {
         "@lezer/lr": "^1.3.9",
         "lezer-feel": "^1.2.0",
@@ -11967,8 +11860,7 @@
     "flatpickr": {
       "version": "4.6.13",
       "resolved": "https://registry.npmjs.org/flatpickr/-/flatpickr-4.6.13.tgz",
-      "integrity": "sha512-97PMG/aywoYpB4IvbvUJi0RQi8vearvU0oov1WW3k0WZPBMrTQVqekSX5CjSG/M4Q3i6A/0FKXC7RyAoAUUSPw==",
-      "dev": true
+      "integrity": "sha512-97PMG/aywoYpB4IvbvUJi0RQi8vearvU0oov1WW3k0WZPBMrTQVqekSX5CjSG/M4Q3i6A/0FKXC7RyAoAUUSPw=="
     },
     "flatted": {
       "version": "3.2.7",
@@ -11980,7 +11872,6 @@
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.5.4.tgz",
       "integrity": "sha512-N7kHdlgsO/v+iD/dMoJKtsSqs5Dz/dXZVebRgJw23LDk+jMi/974zyiOYDziY2JPp8xivq9BmUGwIJMiuSBi7w==",
-      "dev": true,
       "requires": {
         "tabbable": "^6.2.0"
       }
@@ -12348,8 +12239,7 @@
     "ids": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/ids/-/ids-1.0.5.tgz",
-      "integrity": "sha512-XQ0yom/4KWTL29sLG+tyuycy7UmeaM/79GRtSJq6IG9cJGIPeBz5kwDCguie3TwxaMNIc3WtPi0cTa1XYHicpw==",
-      "dev": true
+      "integrity": "sha512-XQ0yom/4KWTL29sLG+tyuycy7UmeaM/79GRtSJq6IG9cJGIPeBz5kwDCguie3TwxaMNIc3WtPi0cTa1XYHicpw=="
     },
     "ieee754": {
       "version": "1.2.1",
@@ -12382,8 +12272,7 @@
     "indexof": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
-      "integrity": "sha512-i0G7hLJ1z0DE8dsqJa2rycj9dBmNKgXBvotXtZYXakU9oivfB9Uj2ZBC27qqef2U58/ZLwalxa1X/RDCdkHtVg==",
-      "dev": true
+      "integrity": "sha512-i0G7hLJ1z0DE8dsqJa2rycj9dBmNKgXBvotXtZYXakU9oivfB9Uj2ZBC27qqef2U58/ZLwalxa1X/RDCdkHtVg=="
     },
     "inflight": {
       "version": "1.0.6",
@@ -13023,7 +12912,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/lang-feel/-/lang-feel-1.1.0.tgz",
       "integrity": "sha512-UxQoWm8G8ne9D+xrVJ4wgVM2nIiggpdCQxX8SAw+ISNFUsehm7xtwohELgXGN8dCZ6C69fsMreAjI+jPURFKdQ==",
-      "dev": true,
       "requires": {
         "@codemirror/autocomplete": "^6.9.1",
         "@codemirror/language": "^6.9.1",
@@ -13047,7 +12935,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/lezer-feel/-/lezer-feel-1.2.0.tgz",
       "integrity": "sha512-OgSjIEAK0YCxhwkuB1qvhqv65XmZiqLGQv8mvMOVUAcdKE6W72VV/sQ9GTgCBkAnmyB1x16WuzNRpEwpJswkkQ==",
-      "dev": true,
       "requires": {
         "@lezer/highlight": "^1.1.6",
         "@lezer/lr": "^1.3.12"
@@ -13112,8 +12999,7 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.get": {
       "version": "4.4.2",
@@ -13181,8 +13067,7 @@
     "luxon": {
       "version": "3.4.4",
       "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.4.4.tgz",
-      "integrity": "sha512-zobTr7akeGHnv7eBOXcRgMeCP6+uyYsczwmeRCauvpvaAltgNyTbLH/+VaEAPUeWBT+1GuNmz4wC/6jtQzbbVA==",
-      "dev": true
+      "integrity": "sha512-zobTr7akeGHnv7eBOXcRgMeCP6+uyYsczwmeRCauvpvaAltgNyTbLH/+VaEAPUeWBT+1GuNmz4wC/6jtQzbbVA=="
     },
     "lz-string": {
       "version": "1.5.0",
@@ -13237,8 +13122,7 @@
     "matches-selector": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/matches-selector/-/matches-selector-1.2.0.tgz",
-      "integrity": "sha512-c4vLwYWyl+Ji+U43eU/G5FwxWd4ZH0ePUsFs5y0uwD9HUEFBXUQ1zUUan+78IpRD+y4pUfG0nAzNM292K7ItvA==",
-      "dev": true
+      "integrity": "sha512-c4vLwYWyl+Ji+U43eU/G5FwxWd4ZH0ePUsFs5y0uwD9HUEFBXUQ1zUUan+78IpRD+y4pUfG0nAzNM292K7ItvA=="
     },
     "media-typer": {
       "version": "0.3.0",
@@ -13282,14 +13166,12 @@
     "min-dash": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-4.1.1.tgz",
-      "integrity": "sha512-r+Z6vxXLSGr+otyCPx9NKPCSixw7LdfZREPTmqfd2a/d5D6w4NCdOxRJs+HyFO6v2pQkyHroGSiINWECK+OWPg==",
-      "dev": true
+      "integrity": "sha512-r+Z6vxXLSGr+otyCPx9NKPCSixw7LdfZREPTmqfd2a/d5D6w4NCdOxRJs+HyFO6v2pQkyHroGSiINWECK+OWPg=="
     },
     "min-dom": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-4.1.0.tgz",
       "integrity": "sha512-1lj1EyoSwY/UmTeT/hhPiZTsq+vK9D+8FAJ/53iK5jT1otkG9rJTixSKdjmTieEvdfES+sKbbTptzaQJhnacjA==",
-      "dev": true,
       "requires": {
         "component-event": "^0.2.1",
         "domify": "^1.4.1",
@@ -13314,8 +13196,7 @@
     "mitt": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
-      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
-      "dev": true
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw=="
     },
     "mkdirp": {
       "version": "0.5.6",
@@ -14074,14 +13955,12 @@
     "preact": {
       "version": "10.17.0",
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.17.0.tgz",
-      "integrity": "sha512-SNsI8cbaCcUS5tbv9nlXuCfIXnJ9ysBMWk0WnB6UWwcVA3qZ2O6FxqDFECMAMttvLQcW/HaNZUe2BLidyvrVYw==",
-      "dev": true
+      "integrity": "sha512-SNsI8cbaCcUS5tbv9nlXuCfIXnJ9ysBMWk0WnB6UWwcVA3qZ2O6FxqDFECMAMttvLQcW/HaNZUe2BLidyvrVYw=="
     },
     "preact-markup": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/preact-markup/-/preact-markup-2.1.1.tgz",
       "integrity": "sha512-8JL2p36mzK8XkspOyhBxUSPjYwMxDM0L5BWBZWxsZMVW8WsGQrYQDgVuDKkRspt2hwrle+Cxr/053hpc9BJwfw==",
-      "dev": true,
       "requires": {}
     },
     "prelude-ls": {
@@ -14544,7 +14423,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/showdown/-/showdown-2.1.0.tgz",
       "integrity": "sha512-/6NVYu4U819R2pUIk79n67SYgJHWCce0a5xTP979WbNp0FL9MN1I1QK662IDU1b6JzKTvmhgI7T7JYIxBi3kMQ==",
-      "dev": true,
       "requires": {
         "commander": "^9.0.0"
       },
@@ -14552,8 +14430,7 @@
         "commander": {
           "version": "9.5.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
-          "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
-          "dev": true
+          "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ=="
         }
       }
     },
@@ -14860,8 +14737,7 @@
     "style-mod": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.0.tgz",
-      "integrity": "sha512-Ca5ib8HrFn+f+0n4N4ScTIA9iTOQ7MaGS1ylHcoVqW9J7w2w8PzN6g9gKmTYgGEBH8e120+RCmhpje6jC5uGWA==",
-      "dev": true
+      "integrity": "sha512-Ca5ib8HrFn+f+0n4N4ScTIA9iTOQ7MaGS1ylHcoVqW9J7w2w8PzN6g9gKmTYgGEBH8e120+RCmhpje6jC5uGWA=="
     },
     "supports-color": {
       "version": "7.2.0",
@@ -14881,8 +14757,7 @@
     "tabbable": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
-      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
-      "dev": true
+      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew=="
     },
     "tapable": {
       "version": "2.2.1",
@@ -14990,8 +14865,7 @@
     "ticky": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ticky/-/ticky-1.0.1.tgz",
-      "integrity": "sha512-RX35iq/D+lrsqhcPWIazM9ELkjOe30MSeoBHQHSsRwd1YuhJO5ui1K1/R0r7N3mFvbLBs33idw+eR6j+w6i/DA==",
-      "dev": true
+      "integrity": "sha512-RX35iq/D+lrsqhcPWIazM9ELkjOe30MSeoBHQHSsRwd1YuhJO5ui1K1/R0r7N3mFvbLBs33idw+eR6j+w6i/DA=="
     },
     "tiny-svg": {
       "version": "3.0.1",
@@ -15215,8 +15089,7 @@
     "w3c-keyname": {
       "version": "2.2.8",
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
-      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
-      "dev": true
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ=="
     },
     "watchpack": {
       "version": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -35,8 +35,10 @@
     "dist"
   ],
   "module": "dist/index.es.js",
+  "dependencies": {
+    "@bpmn-io/form-js": ">=1.1.0"
+  },
   "devDependencies": {
-    "@bpmn-io/form-js": "^1.6.0",
     "@bpmn-io/variable-resolver": "^1.2.0",
     "@rollup/plugin-commonjs": "^25.0.7",
     "@rollup/plugin-json": "^6.1.0",
@@ -71,7 +73,6 @@
     "zeebe-bpmn-moddle": "^1.0.0"
   },
   "peerDependencies": {
-    "@bpmn-io/form-js": ">=1.1.0",
     "@bpmn-io/variable-resolver": "*",
     "bpmn-js": "*"
   }


### PR DESCRIPTION
forms are embedded in the BPMN and should be available as variable completion in bpmn-js only (no form-js) bundles.

related to https://github.com/camunda/camunda-bpmn-js/issues/333

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
